### PR TITLE
Two-level multimaster API

### DIFF
--- a/husky_gazebo/launch/multimaster_husky.launch
+++ b/husky_gazebo/launch/multimaster_husky.launch
@@ -36,20 +36,25 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <node pkg="master_sync_fkie" type="master_sync" name="master_sync">
     <rosparam param="sync_topics" subst_value="True">
       - /public*
+      - /$(arg robot_name)*
     </rosparam>
     <rosparam param="sync_services" subst_value="True">
       - /public*
+      - /$(arg robot_name)*
     </rosparam>
   </node>
 
-  <!-- Topic import/export configuration -->
-  <!-- Export /cmd_vel -->
-  <node pkg="topic_tools" type="relay" args="/husky_velocity_controller/cmd_vel /public/$(arg robot_name)/husky_velocity_controller/cmd_vel" name="$(arg robot_name)_export_cmd_vel"></node>
+  <!-- Public interface configuration -->
+  <!-- Import cmd_vel -->
+  <node pkg="topic_tools" type="relay" args="/public/$(arg robot_name)/cmd_vel /cmd_vel" name="public_$(arg robot_name)_import_cmd_vel"></node>
 
-  <!-- Service import/export configuration -->
+  <!-- Simulation Interface configuration -->
+  <!-- Export cmd_vel -->
+  <node pkg="topic_tools" type="relay" args="/husky_velocity_controller/cmd_vel /$(arg robot_name)/husky_velocity_controller/cmd_vel" name="$(arg robot_name)_export_cmd_vel"></node>
+
   <!-- Import controller interface from Gazebo node -->
-  <node pkg="service_tools" type="relay.py" args="/public/$(arg robot_name)/controller_manager/load_controller /controller_manager/load_controller controller_manager_msgs LoadController" name="$(arg robot_name)_import_gazebo_load_controller"></node>
-  <node pkg="service_tools" type="relay.py" args="/public/$(arg robot_name)/controller_manager/switch_controller /controller_manager/switch_controller controller_manager_msgs SwitchController" name="$(arg robot_name)_import_gazebo_switch_controller"></node>
-  <node pkg="service_tools" type="relay.py" args="/public/$(arg robot_name)/controller_manager/unload_controller /controller_manager/unload_controller controller_manager_msgs UnloadController" name="$(arg robot_name)_import_gazebo_unload_controller"></node>
+  <node pkg="service_tools" type="relay.py" args="/$(arg robot_name)/controller_manager/load_controller /controller_manager/load_controller controller_manager_msgs LoadController" name="$(arg robot_name)_import_gazebo_load_controller"></node>
+  <node pkg="service_tools" type="relay.py" args="/$(arg robot_name)/controller_manager/switch_controller /controller_manager/switch_controller controller_manager_msgs SwitchController" name="$(arg robot_name)_import_gazebo_switch_controller"></node>
+  <node pkg="service_tools" type="relay.py" args="/$(arg robot_name)/controller_manager/unload_controller /controller_manager/unload_controller controller_manager_msgs UnloadController" name="$(arg robot_name)_import_gazebo_unload_controller"></node>
 
 </launch>

--- a/husky_gazebo/launch/two_huskies_multimaster_gazebo.launch
+++ b/husky_gazebo/launch/two_huskies_multimaster_gazebo.launch
@@ -38,27 +38,27 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   </include>
 
   <!-- ROBOT 1 model and configuration files -->
-  <group ns="public/robot1">
+  <group ns="robot1">
     <rosparam command="load" file="$(find husky_control)/config/control.yaml" />
     <include file="$(find husky_gazebo)/launch/description_gazebo.launch">
       <arg name="gps_enabled" value="true"/>
       <arg name="imu_enabled" value="true"/>
       <arg name="front_laser" value="true"/>
       <arg name="init_pose" value="-x 1 -y 1 -z 0" />
-      <arg name="robot_name"  value="public/robot1" />
+      <arg name="robot_name"  value="robot1" />
       <arg name="model"  value="robot1" />
     </include>
   </group>
 
   <!-- ROBOT 2 model and configuration files -->
-  <group ns="public/robot2">
+  <group ns="robot2">
     <rosparam command="load" file="$(find husky_control)/config/control.yaml" />
     <include file="$(find husky_gazebo)/launch/description_gazebo.launch">
       <arg name="gps_enabled" value="true"/>
       <arg name="imu_enabled" value="true"/>
       <arg name="front_laser" value="true"/>
       <arg name="init_pose" value="-x 3 -y 5 -z 0" />
-      <arg name="robot_name"  value="public/robot2" />
+      <arg name="robot_name"  value="robot2" />
       <arg name="model"  value="robot2" />
     </include>
   </group>


### PR DESCRIPTION
This change shows how we can separate the topic/service export configuration necessary for Gazebo from the general public robot interface.

This can be easily separated in a base launch file and a gazebo-only launch file.
